### PR TITLE
Cleanup Navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,23 +31,7 @@ section {
   }
 }
 
-/* TODO: Needs some work */
 ::-webkit-scrollbar {
-  width: 10px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--color-bone);
-}
-
-::-webkit-scrollbar-thumb {
-  background-clip: content-box;
-  background-color: var(--color-bone);
-  border: 2px solid transparent;
-  border-radius: 10px;
-}
-
-main:hover ::-webkit-scrollbar-thumb {
-  background-color: #a8bbbf;
+  display: none;
 }
 </style>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -3,8 +3,8 @@ import MenuItem from '~/components/MenuItem.vue'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
-
 const routes = router.getRoutes()
+
 const mainNav = routes.filter((route) => route.meta.mainNav)
 const utilityNav = routes.filter((route) => route.meta.utilityNav)
 </script>
@@ -33,14 +33,3 @@ const utilityNav = routes.filter((route) => route.meta.utilityNav)
     </nav>
   </header>
 </template>
-
-<style scoped>
-.login:has(.btn-login:focus-visible) {
-  outline: 2px solid var(--color-bone);
-  outline-offset: -2px;
-}
-
-.btn-login:focus-visible {
-  outline: none;
-}
-</style>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -5,7 +5,8 @@ import { useRouter } from 'vue-router'
 const router = useRouter()
 
 const routes = router.getRoutes()
-const loginRoute = routes.pop()
+const mainNav = routes.filter((route) => route.meta.mainNav)
+const utilityNav = routes.filter((route) => route.meta.utilityNav)
 </script>
 
 <template>
@@ -19,11 +20,16 @@ const loginRoute = routes.pop()
       </RouterLink>
 
       <ul class="flex">
-        <li v-for="route in routes" :key="route.name">
+        <li v-for="route in mainNav" :key="route.name">
           <MenuItem :route />
         </li>
       </ul>
-      <MenuItem v-if="loginRoute" :route="loginRoute" class="ml-auto" />
+
+      <ul class="ml-auto flex">
+        <li v-for="route in utilityNav" :key="route.name">
+          <MenuItem :route />
+        </li>
+      </ul>
     </nav>
   </header>
 </template>

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -8,7 +8,7 @@ const { route } = defineProps<{
 
 <template>
   <RouterLink
-    class="menu-item btn-no-style relative flex h-full items-center bg-transparent no-underline"
+    class="menu-item btn-no-style relative flex h-full items-center overflow-hidden bg-transparent no-underline"
     :to="route.path"
   >
     <span class="relative z-20 flex h-full w-full items-center px-4">

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,16 +6,19 @@ const router = createRouter({
     {
       path: '/',
       name: 'Dashboard',
+      meta: { mainNav: true },
       component: () => import('~/views/DashboardView.vue'),
     },
     {
       path: '/about',
       name: 'About',
+      meta: { mainNav: true },
       component: () => import('~/views/AboutView.vue'),
     },
     {
       path: '/login',
       name: 'Login',
+      meta: { utilityNav: true },
       component: () => import('~/views/LoginView.vue'),
     },
   ],

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -11,8 +11,6 @@
 */
 
 .content-grid {
-  @apply grid;
-
   --padding-inline: --spacing(4);
   --content-max-width: 80rem;
   --breakout-max-width: 100rem;
@@ -21,6 +19,7 @@
   --content-size: min(100% - var(--padding-inline) * 2, var(--content-max-width));
   --breakout-size: minmax(0, calc((var(--breakout-max-width) - var(--content-max-width)) / 2));
 
+  display: grid;
   grid-template-columns:
     [full-width-start] var(--full-width-size)
     [breakout-start] var(--breakout-size)


### PR DESCRIPTION
Navigation relied on the `login` route being last in the list of routes. Change to use metadata to tag routes as `mainNav` or `utility` nav. This will clean up route splitting for navigation, and allow for future scalability of the utility nav.